### PR TITLE
Fix wl download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ deploy: push $(WL)
 	$(WL) deploy --watch $(NAME)
 
 $(WL):
-	curl -sSo $(WL) https://downloads.jimdo-platform.net/wl/latest/wl_latest_$(shell uname -s | tr A-Z a-z)_$(shell uname -m | sed "s/x86_64/amd64/")
+	curl -sSLfo $(WL) https://downloads.jimdo-platform.net/wl/latest/wl_latest_$(shell uname -s | tr A-Z a-z)_$(shell uname -m | sed "s/x86_64/amd64/")
 	chmod +x $(WL)
 	$(WL) version
 


### PR DESCRIPTION
After moving wl binaries to GitHub releases, we had to put a redirect between the download URL in use and the actual binary. Therefore we're changing the curl flags to follow redirects as documented here: https://docs.jimdo-platform.net/WL/

FYI @Jimdo/werkzeugschmiede @Jimdo/blue 