### PR TITLE
TOOLS-233 remove dependency to deprecated gobuilder.me

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM alpine
 
-ENV GOST_VERSION v0.1.1
-ENV GOST_HASH 9b42b1ac521ea9287274eb5b38bb34e75dc6f855
+ENV GOST_VERSION 0.1.1
+ENV GOST_HASH f4d0b42294889e14f6b03d76c7e8cc42a4ce9dd8
 
-ADD https://gobuilder.me/get/github.com/golang-id/gost/gost_v0.1.1_linux-386 /gost
-RUN echo "${GOST_HASH}  gost" | sha1sum -c \
- && chmod +x gost
+ADD https://github.com/golang-id/gost/releases/download/v${GOST_VERSION}/gost_${GOST_VERSION}-snapshot_linux_amd64.tar.gz /gost_${GOST_VERSION}-snapshot_linux_amd64.tar.gz
+RUN tar xvfz /gost_${GOST_VERSION}-snapshot_linux_amd64.tar.gz -C /
+
+RUN echo "${GOST_HASH}  /gost" | sha1sum -c
 
 ADD ./site /site
 


### PR DESCRIPTION
and download gost directly from github instead